### PR TITLE
forcing the use of personal_sign for signature

### DIFF
--- a/js/unlock.js
+++ b/js/unlock.js
@@ -97,7 +97,10 @@ jQuery(document).ready(function($) {
           }
         }
       })
-      let signature = await wallet.signMessage(tokenMetadata)
+      let signature = await web3Provider.send("personal_sign", [
+        ethers.utils.hexlify(ethers.utils.toUtf8Bytes(tokenMetadata)),
+        userAddress.toLowerCase()
+      ])
       const tokenEndpoint = `https://locksmith.unlock-protocol.com/api/key/${lockAddress}/user/${userAddress}`
       $.ajax({
         url: tokenEndpoint,


### PR DESCRIPTION
Ethers.js will use `personal_sign` or `eth_sign` depending on the actual provider... This creates issues when the backend expects the signature to have been performed with `personal_sign`.

This PR forces the use of `personal_sign`  and should make purchase successful with Coinbase Wallet!