### PR TITLE
fixing a bug where the unlockProtocol.getState function may not be de…

### DIFF
--- a/js/unlock.js
+++ b/js/unlock.js
@@ -26,7 +26,10 @@ jQuery(document).ready(function($) {
             await web3.currentProvider.enable()
 
             // Get the Unlock status
-            const unlockState = unlockProtocol.getState()
+            const unlockState =
+              unlockProtocol && unlockProtocol.getState
+                ? unlockProtocol.getState()
+                : "locked"
             if (unlockState === "unlocked") {
               $(".has-wallet").hide()
               $(".has-wallet-has-ticket").show()


### PR DESCRIPTION
…fined

Someone reported that bug... this fixes it. It assumes not ticket has been sold if the `getState` function is not defined.